### PR TITLE
Moved all WindowLayoutInfo listeners to RESUMED lifecycle

### DIFF
--- a/app/src/main/java/com/microsoft/device/samples/dualscreenexperience/presentation/MainActivity.kt
+++ b/app/src/main/java/com/microsoft/device/samples/dualscreenexperience/presentation/MainActivity.kt
@@ -94,7 +94,7 @@ class MainActivity : AppCompatActivity() {
     private fun observeWindowLayoutInfo() {
         windowInfoRepository = windowInfoRepository()
         lifecycleScope.launch(Dispatchers.Main) {
-            lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {
+            lifecycle.repeatOnLifecycle(Lifecycle.State.RESUMED) {
                 windowInfoRepository.windowLayoutInfo.collect {
                     onWindowLayoutInfoChanged(it)
                 }

--- a/app/src/main/java/com/microsoft/device/samples/dualscreenexperience/presentation/about/AboutActivity.kt
+++ b/app/src/main/java/com/microsoft/device/samples/dualscreenexperience/presentation/about/AboutActivity.kt
@@ -51,7 +51,7 @@ class AboutActivity : AppCompatActivity() {
     private fun observeWindowLayoutInfo() {
         windowInfoRepository = windowInfoRepository()
         lifecycleScope.launch(Dispatchers.Main) {
-            lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {
+            lifecycle.repeatOnLifecycle(Lifecycle.State.RESUMED) {
                 windowInfoRepository.windowLayoutInfo.collect {
                     onWindowLayoutInfoChanged(it)
                 }

--- a/app/src/main/java/com/microsoft/device/samples/dualscreenexperience/presentation/about/fragments/AboutTeamFragment.kt
+++ b/app/src/main/java/com/microsoft/device/samples/dualscreenexperience/presentation/about/fragments/AboutTeamFragment.kt
@@ -48,7 +48,7 @@ class AboutTeamFragment : Fragment(R.layout.fragment_about_team) {
     private fun observeWindowLayoutInfo(activity: AppCompatActivity) {
         windowInfoRepository = activity.windowInfoRepository()
         lifecycleScope.launch(Dispatchers.Main) {
-            lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {
+            lifecycle.repeatOnLifecycle(Lifecycle.State.RESUMED) {
                 windowInfoRepository.windowLayoutInfo.collect {
                     onWindowLayoutInfoChanged(it)
                 }

--- a/app/src/main/java/com/microsoft/device/samples/dualscreenexperience/presentation/catalog/CatalogListFragment.kt
+++ b/app/src/main/java/com/microsoft/device/samples/dualscreenexperience/presentation/catalog/CatalogListFragment.kt
@@ -55,7 +55,7 @@ class CatalogListFragment : Fragment(), ViewPager.OnPageChangeListener {
     private fun observeWindowLayoutInfo(activity: AppCompatActivity) {
         windowInfoRepository = activity.windowInfoRepository()
         lifecycleScope.launch(Dispatchers.Main) {
-            lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {
+            lifecycle.repeatOnLifecycle(Lifecycle.State.RESUMED) {
                 windowInfoRepository.windowLayoutInfo.collect {
                     onWindowLayoutInfoChanged(it)
                 }

--- a/app/src/main/java/com/microsoft/device/samples/dualscreenexperience/presentation/devmode/DevControlFragment.kt
+++ b/app/src/main/java/com/microsoft/device/samples/dualscreenexperience/presentation/devmode/DevControlFragment.kt
@@ -44,7 +44,7 @@ class DevControlFragment : Fragment() {
     private fun observeWindowLayoutInfo(activity: AppCompatActivity) {
         windowInfoRepository = activity.windowInfoRepository()
         lifecycleScope.launch(Dispatchers.Main) {
-            lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {
+            lifecycle.repeatOnLifecycle(Lifecycle.State.RESUMED) {
                 windowInfoRepository.windowLayoutInfo.collect {
                     onWindowLayoutInfoChanged(it)
                 }

--- a/app/src/main/java/com/microsoft/device/samples/dualscreenexperience/presentation/devmode/DevModeActivity.kt
+++ b/app/src/main/java/com/microsoft/device/samples/dualscreenexperience/presentation/devmode/DevModeActivity.kt
@@ -77,7 +77,7 @@ class DevModeActivity : AppCompatActivity() {
     private fun observeWindowLayoutInfo() {
         windowInfoRepository = windowInfoRepository()
         lifecycleScope.launch(Dispatchers.Main) {
-            lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {
+            lifecycle.repeatOnLifecycle(Lifecycle.State.RESUMED) {
                 windowInfoRepository.windowLayoutInfo.collect {
                     onWindowLayoutInfoChanged(it)
                 }

--- a/app/src/main/java/com/microsoft/device/samples/dualscreenexperience/presentation/launch/LaunchActivity.kt
+++ b/app/src/main/java/com/microsoft/device/samples/dualscreenexperience/presentation/launch/LaunchActivity.kt
@@ -60,7 +60,7 @@ class LaunchActivity : AppCompatActivity() {
     private fun observeWindowLayoutInfo() {
         windowInfoRepository = windowInfoRepository()
         lifecycleScope.launch(Dispatchers.Main) {
-            lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {
+            lifecycle.repeatOnLifecycle(Lifecycle.State.RESUMED) {
                 windowInfoRepository.windowLayoutInfo.collect {
                     onWindowLayoutInfoChanged(it)
                 }

--- a/app/src/main/java/com/microsoft/device/samples/dualscreenexperience/presentation/launch/fragments/SingleScreenLaunchFragment.kt
+++ b/app/src/main/java/com/microsoft/device/samples/dualscreenexperience/presentation/launch/fragments/SingleScreenLaunchFragment.kt
@@ -46,7 +46,7 @@ class SingleScreenLaunchFragment : Fragment() {
     private fun observeWindowLayoutInfo(activity: AppCompatActivity) {
         windowInfoRepository = activity.windowInfoRepository()
         lifecycleScope.launch(Dispatchers.Main) {
-            lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {
+            lifecycle.repeatOnLifecycle(Lifecycle.State.RESUMED) {
                 windowInfoRepository.windowLayoutInfo.collect {
                     onWindowLayoutInfoChanged(it)
                 }

--- a/app/src/main/java/com/microsoft/device/samples/dualscreenexperience/presentation/order/OrderFragment.kt
+++ b/app/src/main/java/com/microsoft/device/samples/dualscreenexperience/presentation/order/OrderFragment.kt
@@ -58,7 +58,7 @@ class OrderFragment : Fragment() {
     private fun observeWindowLayoutInfo(activity: AppCompatActivity) {
         windowInfoRepository = activity.windowInfoRepository()
         lifecycleScope.launch(Dispatchers.Main) {
-            lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {
+            lifecycle.repeatOnLifecycle(Lifecycle.State.RESUMED) {
                 windowInfoRepository.windowLayoutInfo.collect {
                     onWindowLayoutInfoChanged(it)
                 }

--- a/app/src/main/java/com/microsoft/device/samples/dualscreenexperience/presentation/order/OrderReceiptFragment.kt
+++ b/app/src/main/java/com/microsoft/device/samples/dualscreenexperience/presentation/order/OrderReceiptFragment.kt
@@ -62,7 +62,7 @@ class OrderReceiptFragment : Fragment() {
     private fun observeWindowLayoutInfo(activity: AppCompatActivity) {
         windowInfoRepository = activity.windowInfoRepository()
         lifecycleScope.launch(Dispatchers.Main) {
-            lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {
+            lifecycle.repeatOnLifecycle(Lifecycle.State.RESUMED) {
                 windowInfoRepository.windowLayoutInfo.collect {
                     onWindowLayoutInfoChanged(it)
                 }

--- a/app/src/main/java/com/microsoft/device/samples/dualscreenexperience/presentation/product/customize/ProductCustomizeFragment.kt
+++ b/app/src/main/java/com/microsoft/device/samples/dualscreenexperience/presentation/product/customize/ProductCustomizeFragment.kt
@@ -79,7 +79,7 @@ class ProductCustomizeFragment : Fragment() {
     private fun observeWindowLayoutInfo(activity: AppCompatActivity) {
         windowInfoRepository = activity.windowInfoRepository()
         lifecycleScope.launch(Dispatchers.Main) {
-            lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {
+            lifecycle.repeatOnLifecycle(Lifecycle.State.RESUMED) {
                 windowInfoRepository.windowLayoutInfo.collect {
                     onWindowLayoutInfoChanged(it)
                 }

--- a/app/src/main/java/com/microsoft/device/samples/dualscreenexperience/presentation/product/details/ProductDetailsFragment.kt
+++ b/app/src/main/java/com/microsoft/device/samples/dualscreenexperience/presentation/product/details/ProductDetailsFragment.kt
@@ -81,7 +81,7 @@ class ProductDetailsFragment : Fragment() {
     private fun observeWindowLayoutInfo(activity: AppCompatActivity) {
         windowInfoRepository = activity.windowInfoRepository()
         lifecycleScope.launch(Dispatchers.Main) {
-            lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {
+            lifecycle.repeatOnLifecycle(Lifecycle.State.RESUMED) {
                 windowInfoRepository.windowLayoutInfo.collect {
                     onWindowLayoutInfoChanged(it)
                 }

--- a/app/src/main/java/com/microsoft/device/samples/dualscreenexperience/presentation/product/list/ProductListFragment.kt
+++ b/app/src/main/java/com/microsoft/device/samples/dualscreenexperience/presentation/product/list/ProductListFragment.kt
@@ -48,7 +48,7 @@ class ProductListFragment : Fragment() {
     private fun observeWindowLayoutInfo(activity: AppCompatActivity) {
         windowInfoRepository = activity.windowInfoRepository()
         lifecycleScope.launch(Dispatchers.Main) {
-            lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {
+            lifecycle.repeatOnLifecycle(Lifecycle.State.RESUMED) {
                 windowInfoRepository.windowLayoutInfo.collect {
                     onWindowLayoutInfoChanged(it)
                 }

--- a/app/src/main/java/com/microsoft/device/samples/dualscreenexperience/presentation/store/map/StoreMapFragment.kt
+++ b/app/src/main/java/com/microsoft/device/samples/dualscreenexperience/presentation/store/map/StoreMapFragment.kt
@@ -102,7 +102,7 @@ class StoreMapFragment : Fragment() {
     private fun observeWindowLayoutInfo(activity: AppCompatActivity) {
         windowInfoRepository = activity.windowInfoRepository()
         lifecycleScope.launch(Dispatchers.Main) {
-            lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {
+            lifecycle.repeatOnLifecycle(Lifecycle.State.RESUMED) {
                 windowInfoRepository.windowLayoutInfo.collect {
                     onWindowLayoutInfoChanged()
                 }


### PR DESCRIPTION
Moved all WindowLayoutInfo listeners to RESUMED lifecycle instead of STARTED to sync with the binding of the Navigator and also take into account split-screen and resuming from recents